### PR TITLE
In UM2N Dockerfile use firedrake-parmmg as base

### DIFF
--- a/.github/workflows/docker_firedrake-um2n.yml
+++ b/.github/workflows/docker_firedrake-um2n.yml
@@ -15,12 +15,16 @@ on:
       - '.github/workflows/docker_firedrake-um2n.yml'
       - 'docker/Dockerfile.firedrake-um2n'
 
+  # Trigger this workflow when docker_firedrake-parmmg.yml completes on the main branch
+  workflow_run:
+    workflows: 'Build bespoke Firedrake Docker container'
+    types:
+      - completed
+    branches:
+      - main
+
   # Manually trigger the workflow
   workflow_dispatch:
-
-  # Build and push the Docker container every Saturday at 2AM
-  schedule:
-    - cron: '0 2 * * 6'
 
 # Stop the workflow if a new run is requested
 concurrency:

--- a/docker/Dockerfile.firedrake-um2n
+++ b/docker/Dockerfile.firedrake-um2n
@@ -7,15 +7,11 @@ USER firedrake
 WORKDIR /home/firedrake
 
 RUN bash -c "source firedrake/bin/activate && \
+	  pip3 install torch --index-url https://download.pytorch.org/whl/cpu && \
 	  cd firedrake/src && \
-    pip3 install torch --index-url https://download.pytorch.org/whl/cpu && \
-	  git clone https://github.com/mesh-adaptation/movement.git && \
 	  git clone https://github.com/mesh-adaptation/UM2N.git && \
-	  cd movement && \
-	  make install && \
 	  python3 -m pip uninstall cffconvert -y && \
-	  cd ../UM2N && \
-	  python3 -m pip install -e ."
+	  python3 -m pip install -e UM2N"
 
 # NOTE: cffconvert is not currently used in UM2N and requires a conflicting
 # version of jsonschema with other dependencies.

--- a/docker/Dockerfile.firedrake-um2n
+++ b/docker/Dockerfile.firedrake-um2n
@@ -1,7 +1,7 @@
 # Dockerfile for installing Firedrake plus UM2N and its dependencies with CPU support
 
 # Based on firedrake
-FROM firedrakeproject/firedrake-vanilla:latest
+FROM ghcr.io/mesh-adaptation/firedrake-parmmg:latest
 
 USER firedrake
 WORKDIR /home/firedrake


### PR DESCRIPTION
Related to #13. Cuts down the size of UM2N Docker image by about 4GB.