### PR TITLE
Use UM2N container in build_docs.yml

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -60,30 +60,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Reinstall Animate, Goalie, Movement, and UM2N
+      - name: Update Animate, Goalie, Movement, and UM2N
         run: |
           . /home/firedrake/firedrake/bin/activate
           git config --global --add safe.directory '*'
 
-          pip uninstall -y animate
           cd /home/firedrake/firedrake/src/animate/
           git pull
-          pip install -e .
 
-          pip uninstall -y goalie
           cd /home/firedrake/firedrake/src/goalie/
           git pull
-          pip install -e .
 
-          pip uninstall -y movement
           cd /home/firedrake/firedrake/src/movement/
           git pull
-          pip install -e .
 
-          pip uninstall -y UM2N
           cd /home/firedrake/firedrake/src/UM2N/
           git pull
-          pip install -e .
         working-directory: /home/firedrake/output/
         shell: bash
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -64,18 +64,10 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           git config --global --add safe.directory '*'
-
-          cd /home/firedrake/firedrake/src/animate/
-          git pull
-
-          cd /home/firedrake/firedrake/src/goalie/
-          git pull
-
-          cd /home/firedrake/firedrake/src/movement/
-          git pull
-
-          cd /home/firedrake/firedrake/src/UM2N/
-          git pull
+          for REPO in animate goalie movement UM2N; do
+            cd /home/firedrake/firedrake/src/$REPO
+            git pull
+          done
         working-directory: /home/firedrake/output/
         shell: bash
 

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_updates
     container:
-      image: ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+      image: ghcr.io/mesh-adaptation/firedrake-um2n:latest
       options: --user root
       volumes:
         - ${{ github.workspace }}:/home/firedrake/output
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Animate, Goalie, Movement, and UM2N
+      - name: Reinstall Animate, Goalie, Movement, and UM2N
         run: |
           . /home/firedrake/firedrake/bin/activate
           git config --global --add safe.directory '*'
@@ -80,10 +80,10 @@ jobs:
           git pull
           pip install -e .
 
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          cd /home/firedrake/firedrake/src/
-          git clone https://github.com/mesh-adaptation/UM2N.git
-          pip install -e UM2N
+          pip uninstall -y UM2N
+          cd /home/firedrake/firedrake/src/UM2N/
+          git pull
+          pip install -e .
         working-directory: /home/firedrake/output/
         shell: bash
 


### PR DESCRIPTION
Now that #88 made firedrake-um2n use firedrake-parmmg as base, we can use firedrake-um2n container to build docs.

And I think that just `git pull` is enough to get the latest changes to our packages, right? Since they're installed in editable mode (`pip install -e`) 