### PR TITLE
Simplify reusable test workflow

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -35,4 +35,4 @@ jobs:
       - name: 'Run tests'
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python -m coverage run --source=${{ github.repository }} -m pytest -v --durations=20 test && python -m coverage report
+          python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test && python -m coverage report

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -40,5 +40,7 @@ jobs:
         run: |
           . /home/firedrake/firedrake/bin/activate
           ${{ inputs.test-command }}
+          python $(which firedrake-clean)
+          python -m coverage erase
           python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test
           python -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -27,12 +27,6 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: 'Update repo'
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          git config --global --add safe.directory '*'
-          git pull
-
       - name: 'Lint'
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -35,4 +35,5 @@ jobs:
       - name: 'Run tests'
         run: |
           . /home/firedrake/firedrake/bin/activate
-          python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test && python -m coverage report
+          python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test
+          python -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -30,6 +30,7 @@ jobs:
       - name: 'Update repo'
         run: |
           . /home/firedrake/firedrake/bin/activate
+          git config --global --add safe.directory '*'
           git pull
 
       - name: 'Lint'

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: 'firedrake-parmmg'
         type: string
+      test-command:
+        description: 'Command to run before running tests'
+        required: false
+        type: string
 
 # Cancel jobs running if new commits are pushed
 concurrency:
@@ -35,5 +39,6 @@ jobs:
       - name: 'Run tests'
         run: |
           . /home/firedrake/firedrake/bin/activate
+          ${{ inputs.test-command }}
           python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test
           python -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -3,18 +3,6 @@ name: 'Reusable Test Suite'
 on:
   workflow_call:
     inputs:
-      install-command:
-        description: 'Command to install the package'
-        required: true
-        type: string
-      test-command:
-        description: 'Command to run the tests'
-        required: true
-        type: string
-      changed-files-patterns:
-        description: 'File patterns to check for changes'
-        required: true
-        type: string
       docker-image:
         description: 'Name of the Firedrake Docker image to use'
         required: false
@@ -39,41 +27,17 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: 'Determine files differing from target branch'
-        id: changed-files
-        if: ${{ github.event_name != 'push' && github.ref != 'refs/heads/main' }}
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            .github/workflows/test_suite.yml
-            ${{ inputs.changed-files-patterns }}
-
-      - name: 'Cleanup'
-        if: ${{ always() }}
-        run: |
-          cd ..
-          rm -rf build
-
-      - name: 'Setup Python'
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.12'
-
-      - name: 'Install Package'
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+      - name: 'Update repo'
         run: |
           . /home/firedrake/firedrake/bin/activate
-          ${{ inputs.install-command }}
+          git pull
 
       - name: 'Lint'
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
         run: |
           . /home/firedrake/firedrake/bin/activate
           make lint
 
-      - name: 'Run Tests'
-        if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (steps.changed-files.outcome == 'success' && steps.changed-files.outputs.any_changed == 'true') || github.event_name == 'schedule' }}
+      - name: 'Run tests'
         run: |
           . /home/firedrake/firedrake/bin/activate
-          ${{ inputs.test-command }}
+          python -m coverage run --source=${{ github.repository }} -m pytest -v --durations=20 test && python -m coverage report


### PR DESCRIPTION
Related PRs:
- [x] Animate: https://github.com/mesh-adaptation/animate/pull/166
- [x] Goalie: https://github.com/mesh-adaptation/goalie/pull/257 
- [x] Movement: https://github.com/mesh-adaptation/movement/pull/137
- [x] UM2N: https://github.com/mesh-adaptation/UM2N/pull/64

---

This PR simplifies the `reusable_test_suite.yml` workflow:
- Not using the `changed-files` action; instead, the triggers are to be set in the Animate/Goalie/Movement/UM2N workflows using the `paths` syntax
- The `build` directory doesn't exist so `rm -rf build` does nothing (I guess this was a copy-paste error from the docs build)
- Not unnecessarily installing python with `actions/setup-python@v2`
- Not uninstalling and installing Animate/Goalie/Movement/UM2N again since `actions/checkout@v4` fetches the repository at the state of the commit that triggered the workflow, so it is always up to date
- In the "Run tests" step we have so far passed commands here from other repos, where I think `export GITHUB_ACTIONS_TEST_RUN=1` is unnecessary (not used anywhere?)

And one addition:
- Print missing statements in coverage (i.e., added the `-m` flag in `python -m coverage report -m`)