### PR TITLE
Updates to `firedrake-parmmg` and testing due to Firedrake's new `pip install`

### DIFF
--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build and Push Docker Container'
         uses: docker/build-push-action@v5
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: true
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
-          tags: ${{ inputs.docker-image-tag }}
+          tags: 'ghcr.io/mesh-adaptation/firedrake-parmmg:pip'

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Build and Push Docker Container'
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
-          tags: 'ghcr.io/mesh-adaptation/firedrake-parmmg:pip'
+          tags: ${{ inputs.docker-image-tag }}

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -46,8 +46,4 @@ jobs:
           . /home/firedrake/firedrake-venv/bin/activate
           ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
-          python3 -m coverage erase
-          python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -k "not parallel" test
-          mpiexec -n 2 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[2] test
-          mpiexec -n 3 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[3] test
-          python3 -m coverage report -m
+          make coverage

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -25,29 +25,26 @@ jobs:
     container:
       image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
       options: --user root
-    # Allow executing mpiexec as root
     env:
+      # Allow executing mpiexec as root
       OMPI_ALLOW_RUN_AS_ROOT: '1'
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
+      # Since we are root we need to set PYTHONPATH to find the installed packages
+      PYTHONPATH: /home/firedrake/.local/lib/python3.12/site-packages
 
     steps:
       - name: 'Check out the repo'
         id: checkout
-        uses: actions/checkout@v4     
+        uses: actions/checkout@v4
 
       - name: 'Install package'
-        run: |
-          . /home/firedrake/firedrake-venv/bin/activate
-          pip install --break-system-packages -e .[dev]
+        run: pip install --break-system-packages -e .[dev]
 
       - name: 'Lint'
-        run: |
-          . /home/firedrake/firedrake-venv/bin/activate
-          make lint
+        run: make lint
 
       - name: 'Run tests'
         run: |
-          . /home/firedrake/firedrake-venv/bin/activate
           ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           make coverage

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -27,6 +27,18 @@ jobs:
       options: --user root
 
     steps:
+      - name: Set environment variables
+        run: |
+          echo "PETSC_DIR=/home/firedrake/petsc" >> $GITHUB_ENV
+          echo "PETSC_ARCH=arch-firedrake-default" >> $GITHUB_ENV
+          echo "PATH=/home/firedrake/petsc/arch-firedrake-default/bin:/home/firedrake/.local/bin:$PATH" >> $GITHUB_ENV
+          echo "HDF5_MPI=ON" >> $GITHUB_ENV
+          echo "CC=mpicc" >> $GITHUB_ENV
+          echo "CXX=mpicxx" >> $GITHUB_ENV
+          echo "CFLAGS=-mtune=generic" >> $GITHUB_ENV
+          echo "CPPFLAGS=-mtune=generic" >> $GITHUB_ENV
+          echo "MPICC=mpicc" >> $GITHUB_ENV
+
       - name: 'Check out the repo'
         id: checkout
         uses: actions/checkout@v4     

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -30,7 +30,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT: '1'
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
       # Since we are root we need to set PYTHONPATH to find the installed packages
-      PYTHONPATH: /home/firedrake/.local/lib/python3.12/site-packages
+      PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/.local/lib/python3.12/site-packages
 
     steps:
       - name: 'Check out the repo'
@@ -42,9 +42,6 @@ jobs:
 
       - name: 'Lint'
         run: make lint
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: 'Run tests'
         run: |

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -25,6 +25,10 @@ jobs:
     container:
       image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
       options: --user root
+    # Allow executing mpiexec as root
+    env:
+      OMPI_ALLOW_RUN_AS_ROOT: '1'
+      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
 
     steps:
       - name: 'Check out the repo'

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -32,21 +32,16 @@ jobs:
         uses: actions/checkout@v4     
 
       - name: 'Install package'
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          git config --global --add safe.directory '*'
-          make install_dev
+        run: pip install --break-system-packages -e .[dev]
 
       - name: 'Lint'
-        run: |
-          . /home/firedrake/firedrake/bin/activate
-          make lint
+        run: make lint
 
       - name: 'Run tests'
         run: |
-          . /home/firedrake/firedrake/bin/activate
           ${{ inputs.test-command }}
-          python $(which firedrake-clean)
-          python -m coverage erase
-          python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test
-          python -m coverage report -m
+          python3 $(which firedrake-clean)
+          python3 -m coverage erase
+          python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -k "not test_parallel.py" test
+          mpiexec -n 2 python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[2] test
+          python3 -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -43,6 +43,9 @@ jobs:
       - name: 'Lint'
         run: make lint
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: 'Run tests'
         run: |
           ${{ inputs.test-command }}

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -48,7 +48,11 @@ jobs:
           ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           python3 -m coverage erase
-          python3 -m coverage run --parallel-mode --source=animate -m pytest -v -k "parallel[1] or not parallel" test
-          mpiexec -n 2 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[2] test
+          python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -k "parallel[1] or not parallel" test
+          if pytest --collect-only -m parallel[2] test | grep -q 'no tests collected'; then
+            echo "No parallel[2] tests found, skipping mpiexec command."
+          else
+            mpiexec -n 2 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[2] test
+          fi
           python3 -m coverage combine
           python3 -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -27,33 +27,27 @@ jobs:
       options: --user root
 
     steps:
-      - name: Set environment variables
-        run: |
-          echo "PETSC_DIR=/home/firedrake/petsc" >> $GITHUB_ENV
-          echo "PETSC_ARCH=arch-firedrake-default" >> $GITHUB_ENV
-          echo "PATH=/home/firedrake/petsc/arch-firedrake-default/bin:/home/firedrake/.local/bin:$PATH" >> $GITHUB_ENV
-          echo "HDF5_MPI=ON" >> $GITHUB_ENV
-          echo "CC=mpicc" >> $GITHUB_ENV
-          echo "CXX=mpicxx" >> $GITHUB_ENV
-          echo "CFLAGS=-mtune=generic" >> $GITHUB_ENV
-          echo "CPPFLAGS=-mtune=generic" >> $GITHUB_ENV
-          echo "MPICC=mpicc" >> $GITHUB_ENV
-
       - name: 'Check out the repo'
         id: checkout
         uses: actions/checkout@v4     
 
       - name: 'Install package'
-        run: pip install --break-system-packages -e .[dev]
+        run: |
+          . /home/firedrake/firedrake-venv/bin/activate
+          pip install --break-system-packages -e .[dev]
 
       - name: 'Lint'
-        run: make lint
+        run: |
+          . /home/firedrake/firedrake-venv/bin/activate
+          make lint
 
       - name: 'Run tests'
         run: |
+          . /home/firedrake/firedrake-venv/bin/activate
           ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           python3 -m coverage erase
-          python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -k "not test_parallel.py" test
-          mpiexec -n 2 python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[2] test
+          python3 -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -k "not parallel" test
+          mpiexec -n 2 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[2] test
+          mpiexec -n 3 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v --durations=20 -m parallel[3] test
           python3 -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -43,16 +43,21 @@ jobs:
       - name: 'Lint'
         run: make lint
 
-      - name: 'Run tests'
+      - name: 'Run serial tests'
         run: |
-          ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           python3 -m coverage erase
           python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -k "parallel[1] or not parallel" test
+
+      - name: 'Run parallel tests (nprocs = 2)'
+        run: |
           if pytest --collect-only -m parallel[2] test | grep -q 'no tests collected'; then
-            echo "No parallel[2] tests found, skipping mpiexec command."
+            echo "No parallel[2] tests found."
           else
             mpiexec -n 2 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[2] test
           fi
+
+      - name: 'Generate coverage report'
+        run: |
           python3 -m coverage combine
           python3 -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -47,4 +47,8 @@ jobs:
         run: |
           ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
-          make coverage
+          python3 -m coverage erase
+          python3 -m coverage run --parallel-mode --source=animate -m pytest -v -k "parallel[1] or not parallel" test
+          mpiexec -n 2 python3 -m coverage run --parallel-mode --source=animate -m pytest -v -m parallel[2] test
+          python3 -m coverage combine
+          python3 -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -23,7 +23,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
       options: --user root
 
     steps:

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -23,7 +23,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
       options: --user root
     env:
       # Allow executing mpiexec as root

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -30,7 +30,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT: '1'
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
       # Since we are root we need to set PYTHONPATH to find the installed packages
-      PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/.local/lib/python3.12/site-packages
+      PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/animate:/home/firedrake/goalie:/home/firedrake/movement:/home/firedrake/.local/lib/python3.12/site-packages
 
     steps:
       - name: 'Check out the repo'

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -48,11 +48,12 @@ ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
 ENV PATH="/home/firedrake/.local/bin:$PATH" 
 
-# Install Firedrake
+# Install Firedrake; pass --break-system-packages since we are installing outside of a
+# virtual environment
 RUN pip install --break-system-packages --verbose --no-binary h5py --src . -e \
         git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[test]
 
-# Install Animate, Movement, Goalie
+# Install Animate, Movement, Goalie and their dependencies
 RUN git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -2,39 +2,7 @@
 # as well as Animate, Goalie, and Movement. Based off
 # https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.vanilla
 
-FROM ubuntu:latest
-
-# Set '-o pipefail' to avoid linter error (https://github.com/hadolint/hadolint/wiki/DL4006)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Use a more sane locale
-ENV LC_ALL=C.UTF-8
-
-# Avoid tzdata prompt
-# (https://stackoverflow.com/questions/61388002/how-to-avoid-question-during-the-docker-build)
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TZ=Europe/London
-
-# Install 'parallel' because it is needed by 'firedrake-run-split-tests'
-RUN apt-get update \
-    && apt-get -y install curl parallel python3 python3-venv sudo \
-    && rm -rf /var/lib/apt/lists/*
-
-# Change the `ubuntu` user to `firedrake`
-# and ensure that we do not run as root on self-hosted systems
-RUN usermod -d /home/firedrake -m ubuntu \
-    && usermod -l firedrake ubuntu \
-    && groupmod -n firedrake ubuntu \
-    && usermod -aG sudo firedrake \
-    && echo "firedrake:docker" | chpasswd \
-    && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
-    && ldconfig
-
-USER firedrake
-WORKDIR /home/firedrake
-
-ENV OMP_NUM_THREADS=1
-ENV OPENBLAS_NUM_THREADS=1
+FROM firedrakeproject/firedrake-env:latest
 
 # Download firedrake-configure
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-configure
@@ -45,13 +13,21 @@ RUN sudo apt-get update \
         $(python3 ./firedrake-configure --show-system-packages) \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install PETSc. We set the compiler optimisation flags manually here to
-# remove the default of '-march=native' which is not suitable for Docker images.
-# We use 'sed' to make sure that the options are appended.
+# Install PETSc with additional packages for mesh adaptation. 
+# We set the compiler optimisation flags manually here to remove the default of
+# '-march=native' which is not suitable for Docker images.
 RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
     && cd petsc \
     && python3 ../firedrake-configure --show-petsc-configure-options | \
-        sed "s/$/ --COPTFLAGS='-O3 -mtune=generic' --CXXOPTFLAGS='-O3 -mtune=generic' --FOPTFLAGS='-O3 -mtune=generic' --download-chaco --download-eigen --download-parmetis --download-mmg --download-parmmg/" | \
+        sed "s/$/ \
+            --COPTFLAGS='-O3 -mtune=generic' \
+            --CXXOPTFLAGS='-O3 -mtune=generic' \
+            --FOPTFLAGS='-O3 -mtune=generic' \
+            --download-chaco \
+            --download-eigen \
+            --download-parmetis \
+            --download-mmg \
+            --download-parmmg/" | \
         xargs -L1 ./configure --with-make-np=12 \
     && make \
     && make check \
@@ -61,27 +37,25 @@ RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
     && rm -f ./src/**/tests/output/* \
     && cd ..
 
+# PETSc environment variables
 ENV PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=arch-firedrake-default
 ENV PATH="$PETSC_DIR/$PETSC_ARCH/bin:$PATH" 
 
+# Compiler settings
 ENV HDF5_MPI=ON
 ENV CC=mpicc CXX=mpicxx
 ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
 ENV PATH="/home/firedrake/.local/bin:$PATH" 
 
-# Create a venv and install Firedrake
-RUN python3 -m venv firedrake-venv && \
-    source firedrake-venv/bin/activate && \
-    pip install --upgrade pip && \
-    pip install --verbose --no-binary h5py --src . -e \
+# Install Firedrake
+RUN pip install --break-system-packages --verbose --no-binary h5py --src . -e \
         git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[test]
 
 # Install Animate, Movement, Goalie
-RUN source firedrake-venv/bin/activate && \
-    git clone https://github.com/mesh-adaptation/animate.git && \
+RUN git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
-    pip install -e animate[dev] && \
-    pip install -e movement[dev] && \
-    pip install -e goalie[dev]
+    pip install --break-system-packages -e animate[dev] && \
+    pip install --break-system-packages -e movement[dev] && \
+    pip install --break-system-packages -e goalie[dev]

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -1,5 +1,5 @@
 # Dockerfile for installing Firedrake with mesh adaptation support via Mmg and ParMmg,
-# as well as Animate, Goalie, and Movement
+# as well as Animate, Goalie, and Movement. Based off
 # https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.vanilla
 
 FROM ubuntu:latest
@@ -36,25 +36,21 @@ WORKDIR /home/firedrake
 ENV OMP_NUM_THREADS=1
 ENV OPENBLAS_NUM_THREADS=1
 
-# Firedrake arch to build
-ARG ARCH="default"
-
 # Download firedrake-configure
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-configure
 
 # Install system dependencies
 RUN sudo apt-get update \
     && sudo apt-get -y install \
-        $(python3 ./firedrake-configure --arch $ARCH --show-system-packages) \
+        $(python3 ./firedrake-configure --show-system-packages) \
     && sudo rm -rf /var/lib/apt/lists/*
-
 
 # Install PETSc. We set the compiler optimisation flags manually here to
 # remove the default of '-march=native' which is not suitable for Docker images.
 # We use 'sed' to make sure that the options are appended.
 RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
     && cd petsc \
-    && python3 ../firedrake-configure --arch $ARCH --show-petsc-configure-options | \
+    && python3 ../firedrake-configure --show-petsc-configure-options | \
         sed "s/$/ --COPTFLAGS='-O3 -mtune=generic' --CXXOPTFLAGS='-O3 -mtune=generic' --FOPTFLAGS='-O3 -mtune=generic' --download-chaco --download-eigen --download-parmetis --download-mmg --download-parmmg/" | \
         xargs -L1 ./configure --with-make-np=12 \
     && make \
@@ -65,17 +61,8 @@ RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
     && rm -f ./src/**/tests/output/* \
     && cd ..
 
-ENV PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=arch-firedrake-$ARCH
+ENV PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=arch-firedrake-default
 ENV PATH="$PETSC_DIR/$PETSC_ARCH/bin:$PATH" 
-
-# Install SLEPc
-RUN git clone --depth 1 https://github.com/firedrakeproject/slepc.git \
-    && cd slepc \
-    && ./configure \
-    && make SLEPC_DIR=/home/firedrake/slepc \
-    && cd ..
-
-ENV SLEPC_DIR=/home/firedrake/slepc
 
 ENV HDF5_MPI=ON
 ENV CC=mpicc CXX=mpicxx
@@ -83,15 +70,18 @@ ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
 ENV PATH="/home/firedrake/.local/bin:$PATH" 
 
-# Install Firedrake, pass --break-system-packages because we don't want the
-# container to need a venv.
-RUN pip install --break-system-packages --verbose --no-binary h5py --src . \
-        --editable git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[ci]
+# Create a venv and install Firedrake
+RUN python3 -m venv firedrake-venv && \
+    source firedrake-venv/bin/activate && \
+    pip install --upgrade pip && \
+    pip install --verbose --no-binary h5py --src . -e \
+        git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[test]
 
-# Install Firedrake and Animate, Movement, Goalie
-RUN git clone https://github.com/mesh-adaptation/animate.git && \
+# Install Animate, Movement, Goalie
+RUN source firedrake-venv/bin/activate && \
+    git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
-    pip install --break-system-packages --editable animate[dev] && \
-    pip install --break-system-packages --editable movement[dev] && \
-    pip install --break-system-packages --editable goalie[dev]
+    pip install -e animate[dev] && \
+    pip install -e movement[dev] && \
+    pip install -e goalie[dev]

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -1,115 +1,23 @@
 # Dockerfile for installing Firedrake with mesh adaptation support via Mmg and ParMmg,
 # as well as Animate, Goalie, and Movement
+# https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.vanilla
 
-# First stage: Build MPICH and PETSc. Based off
-# https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.env
-FROM ubuntu:24.04 AS petscbuild
+FROM ubuntu:latest
 
-USER root
-WORKDIR /home/firedrake
+# Set '-o pipefail' to avoid linter error (https://github.com/hadolint/hadolint/wiki/DL4006)
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Use a more sane locale
+ENV LC_ALL=C.UTF-8
+
+# Avoid tzdata prompt
+# (https://stackoverflow.com/questions/61388002/how-to-avoid-question-during-the-docker-build)
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/London
+
+# Install 'parallel' because it is needed by 'firedrake-run-split-tests'
 RUN apt-get update \
-    && apt-get -y dist-upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
-        curl vim docker.io openssh-client build-essential autoconf automake \
-        cmake gfortran git libopenblas-serial-dev libtool python3-dev python3-pip python3-tk \
-        python3-venv python3-requests zlib1g-dev libboost-dev sudo gmsh bison flex ninja-build \
-        libocct-ocaf-dev libocct-data-exchange-dev swig graphviz libcurl4-openssl-dev libxml2-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Fetch PETSc
-RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git
-
-# Build MPICH manually because we don't want PETSc to build it twice
-RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
-    cd petsc; \
-    ./configure \
-        --COPTFLAGS=-O3 -march=native -mtune=native \
-        --CXXOPTFLAGS=-O3 -march=native -mtune=native \
-        --FOPTFLAGS=-O3 -march=native -mtune=native \
-        --with-c2html=0 \
-        --with-debugging=0 \
-        --with-fortran-bindings=0 \
-        --with-make-np=12 \
-        --with-shared-libraries=1 \
-        --with-zlib \
-        --download-eigen \
-        --download-fftw \
-        --download-hdf5 \
-        --download-hwloc \
-        --download-hypre \
-        --download-metis \
-        --download-mmg \
-        --download-mumps \
-        --download-mpich \
-        --download-mpich-device=ch3:sock \
-        --download-netcdf \
-        --download-parmmg \
-        --download-pastix \
-        --download-pnetcdf \
-        --download-ptscotch \
-        --download-scalapack \
-        --download-suitesparse \
-        --download-superlu_dist \
-        PETSC_ARCH=packages; \
-        mv ${PACKAGES}/include/petscconf.h ${PACKAGES}/include/old_petscconf.nope;' && \
-    rm -rf /home/firedrake/petsc/**/externalpackages && \
-    rm -rf /home/firedrake/petsc/src/docs && \
-    rm -f /home/firedrake/petsc/src/**/tutorials/output/* && \
-    rm -f /home/firedrake/petsc/src/**/tests/output/*
-# Don't run make here, we only want MPICH and HWLOC
-# It is also necessary to move `petscconf.h` so packages isn't treated like a working PETSc
-
-# Build PETSc
-RUN bash -c 'export PACKAGES=/home/firedrake/petsc/packages; \
-    cd petsc; \
-    ./configure \
-        --COPTFLAGS=-O3 -march=native -mtune=native \
-        --CXXOPTFLAGS=-O3 -march=native -mtune=native \
-        --FOPTFLAGS=-O3 -march=native -mtune=native \
-        --with-c2html=0 \
-        --with-debugging=0 \
-        --with-fortran-bindings=0 \
-        --with-make-np=12 \
-        --with-shared-libraries=1 \
-        --with-bison \
-        --with-flex \
-        --with-zlib \
-        --with-eigen-dir=${PACKAGES} \
-        --with-fftw-dir=${PACKAGES} \
-        --with-hdf5-dir=${PACKAGES} \
-        --with-hwloc-dir=${PACKAGES} \
-        --with-hypre-dir=${PACKAGES} \
-        --with-metis-dir=${PACKAGES} \
-        --with-mmg-dir=${PACKAGES} \
-        --with-mpi-dir=${PACKAGES} \
-        --with-mumps-dir=${PACKAGES} \
-        --with-netcdf-dir=${PACKAGES} \
-        --with-parmmg-dir=${PACKAGES} \
-        --with-pastix-dir=${PACKAGES} \
-        --with-pnetcdf-dir=${PACKAGES} \
-        --with-ptscotch-dir=${PACKAGES} \
-        --with-scalapack-dir=${PACKAGES} \
-        --with-suitesparse-dir=${PACKAGES} \
-        --with-superlu_dist-dir=${PACKAGES} \
-        PETSC_ARCH=default; \
-    make PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=default all; \
-    mv ${PACKAGES}/include/eigen3/Eigen ${PACKAGES}/include' && \
-    rm -rf /home/firedrake/petsc/**/externalpackages && \
-    rm -rf /home/firedrake/petsc/src/docs && \
-    rm -f /home/firedrake/petsc/src/**/tutorials/output/* && \
-    rm -f /home/firedrake/petsc/src/**/tests/output/*
-
-# Final stage: Install Firedrake and Animate, Movement, Goalie
-FROM ubuntu:24.04
-
-RUN apt-get update \
-    && apt-get -y dist-upgrade \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
-        curl vim docker.io openssh-client build-essential autoconf automake \
-        cmake gfortran git libopenblas-serial-dev libtool python3-dev python3-pip python3-tk \
-        python3-venv python3-requests zlib1g-dev libboost-dev sudo gmsh bison flex ninja-build \
-        libocct-ocaf-dev libocct-data-exchange-dev swig graphviz libcurl4-openssl-dev libxml2-dev \
+    && apt-get -y install curl parallel python3 python3-venv sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Change the `ubuntu` user to `firedrake`
@@ -119,42 +27,71 @@ RUN usermod -d /home/firedrake -m ubuntu \
     && groupmod -n firedrake ubuntu \
     && usermod -aG sudo firedrake \
     && echo "firedrake:docker" | chpasswd \
-    && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers \
+    && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && ldconfig
 
 USER firedrake
 WORKDIR /home/firedrake
 
-# Copy PETSc and MPI directories from petscbuild stage
-COPY --from=petscbuild /home/firedrake/petsc /home/firedrake/petsc
-
-# Set some useful environment variables
-ENV LC_ALL=C.UTF-8
-ENV PETSC_ARCH=default
-ENV PETSC_DIR=/home/firedrake/petsc
-ENV MPICH_DIR=${PETSC_DIR}/packages/bin
-ENV HDF5_DIR=${PETSC_DIR}/packages
-ENV HDF5_MPI=ON
 ENV OMP_NUM_THREADS=1
 ENV OPENBLAS_NUM_THREADS=1
 
+# Firedrake arch to build
+ARG ARCH="default"
+
+# Download firedrake-configure
+RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-configure
+
+# Install system dependencies
+RUN sudo apt-get update \
+    && sudo apt-get -y install \
+        $(python3 ./firedrake-configure --arch $ARCH --show-system-packages) \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+
+# Install PETSc. We set the compiler optimisation flags manually here to
+# remove the default of '-march=native' which is not suitable for Docker images.
+# We use 'sed' to make sure that the options are appended.
+RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
+    && cd petsc \
+    && python3 ../firedrake-configure --arch $ARCH --show-petsc-configure-options | \
+        sed "s/$/ --COPTFLAGS='-O3 -mtune=generic' --CXXOPTFLAGS='-O3 -mtune=generic' --FOPTFLAGS='-O3 -mtune=generic' --download-chaco --download-eigen --download-parmetis --download-mmg --download-parmmg/" | \
+        xargs -L1 ./configure --with-make-np=12 \
+    && make \
+    && make check \
+    && rm -rf ./**/externalpackages \
+    && rm -rf ./src/docs \
+    && rm -f ./src/**/tutorials/output/* \
+    && rm -f ./src/**/tests/output/* \
+    && cd ..
+
+ENV PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=arch-firedrake-$ARCH
+ENV PATH="$PETSC_DIR/$PETSC_ARCH/bin:$PATH" 
+
+# Install SLEPc
+RUN git clone --depth 1 https://github.com/firedrakeproject/slepc.git \
+    && cd slepc \
+    && ./configure \
+    && make SLEPC_DIR=/home/firedrake/slepc \
+    && cd ..
+
+ENV SLEPC_DIR=/home/firedrake/slepc
+
+ENV HDF5_MPI=ON
+ENV CC=mpicc CXX=mpicxx
+ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
+ENV MPICC=$CC
+ENV PATH="/home/firedrake/.local/bin:$PATH" 
+
+# Install Firedrake, pass --break-system-packages because we don't want the
+# container to need a venv.
+RUN pip install --break-system-packages --verbose --no-binary h5py --src . \
+        --editable git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[ci]
+
 # Install Firedrake and Animate, Movement, Goalie
-RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-install && \
-    bash -c "python3 firedrake-install \
-		--no-package-manager \
-		--disable-ssh \
-		--honour-petsc-dir \
-		--mpihome=${MPICH_DIR} \
-		--mpicc=${MPICH_DIR}/mpicc \
-		--mpicxx=${MPICH_DIR}/mpicxx \
-		--mpif90=${MPICH_DIR}/mpif90 \
-		--mpiexec=${MPICH_DIR}/mpiexec \
-		--install thetis && \
-    source firedrake/bin/activate && \
-    cd firedrake/src && \
-    git clone https://github.com/mesh-adaptation/animate.git && \
+RUN git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
-    cd animate && make install_dev && \
-    cd ../movement && make install_dev && \
-    cd ../goalie && make install_dev"
+    pip install --break-system-packages --editable animate[dev] && \
+    pip install --break-system-packages --editable movement[dev] && \
+    pip install --break-system-packages --editable goalie[dev]


### PR DESCRIPTION
Firedrake is now installable via `pip`, with `firedrake-install` now giving a `FutureWarning`. For an overview of changes on Firedrake side, see https://github.com/firedrakeproject/firedrake/pull/4011. This PR updates the `firedrake-parmmg` image and `reusable_test_suite.yml` workflows to conform to those changes, as described below.

General:
- The `firedrake-parmmg` image is now only 2.4GB and the build time is almost twice as fast (25 min faster)!
- Mesh adaptation repos are now cloned to the home directory (they used to be under `/home/firedrake/firedrake/src`). Firedrake made this change in their containers too so I am just following their structure.
- It is no longer necessary to create a virtual environment, so I don't create one (to be consistent with Firedrake's containers again).

Dependencies:
- We used to install [hypre](https://petsc.org/release/manualpages/PC/PCHYPRE/) (it's listed in our [petsc-configure-options.txt](https://github.com/mesh-adaptation/docs/blob/main/install/petsc_configure_options.txt)) but I don't think we need this so I do not install it here.
- Firedrake installs https://github.com/firedrakeproject/slepc in their vanilla container, but we didn't have this in our old containers so I don't install it now either.
- Firedrake no longer installs `vtk` by default, so I added it to dependencies of packages.

Parallel tests:
- I realised that parallel tests did not contribute to the coverage report. This is now fixed.
- The container now ships OpenMPI, so we can't run serial and parallel tests with a single `pytest` call.
- Parallel tests are now run with `mpiexec -n N python3 -m pytest ...`, which is strongly discouraged to be executed as root (see https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man1/mpirun.1.html#the-allow-run-as-root-option), which we do in `reusable_test_suite.yml`. Long story short, I think this is fine to do in our workflow since it uses a container so we're not really concerned about something going wrong.
- The `reusable_test_suite.yml` now runs serial and parallel tests in two separate steps, and the coverage report is generated in a further separate step.

Related PRs:
- Animate: https://github.com/mesh-adaptation/animate/pull/175
- Goalie: https://github.com/mesh-adaptation/goalie/pull/291
- Movement: https://github.com/mesh-adaptation/movement/pull/159