### PR TITLE
Run parallel tests with 3 processes in the CI

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: 'Run serial tests'
         run: |
-          ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           python3 -m coverage erase
           python3 -m coverage run --parallel-mode --source=${REPO_NAME} -m pytest -v -k "parallel[1] or not parallel" test

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -19,7 +19,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
       options: --user root
     env:
       # Name of the repository that triggered the workflow

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -58,6 +58,14 @@ jobs:
             mpiexec -n 2 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[2] test
           fi
 
+      - name: 'Run parallel tests (nprocs = 3)'
+        run: |
+          if pytest --collect-only -m parallel[3] test | grep -q 'no tests collected'; then
+            echo "No parallel[3] tests found."
+          else
+            mpiexec -n 3 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[3] test
+          fi
+
       - name: 'Generate coverage report'
         run: |
           python3 -m coverage combine

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -19,7 +19,7 @@ jobs:
     name: 'Test suite'
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:pip
       options: --user root
     env:
       # Name of the repository that triggered the workflow

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: 'Run serial tests'
         run: |
+          ${{ inputs.test-command }}
           python3 $(which firedrake-clean)
           python3 -m coverage erase
           python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -k "parallel[1] or not parallel" test

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -29,7 +29,7 @@ jobs:
       OMPI_ALLOW_RUN_AS_ROOT: '1'
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
       # Since we are root we need to set PYTHONPATH to find the installed packages
-      PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/animate:/home/firedrake/goalie:/home/firedrake/movement:/home/firedrake/.local/lib/python3.12/site-packages
+      PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/animate:/home/firedrake/goalie:/home/firedrake/movement:/home/firedrake/UM2N:/home/firedrake/.local/lib/python3.12/site-packages
 
     steps:
       - name: 'Check out the repo'
@@ -64,7 +64,7 @@ jobs:
           if pytest --collect-only -m parallel[3] test | grep -q 'no tests collected'; then
             echo "No parallel[3] tests found."
           else
-            mpiexec -n 3 --use-hwthread-cpus python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[3] test
+            mpiexec -n 3 --use-hwthread-cpus python3 -m coverage run --parallel-mode --source=${REPO_NAME} -m pytest -v -m parallel[3] test
           fi
 
       - name: 'Generate coverage report'

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -63,7 +63,7 @@ jobs:
           if pytest --collect-only -m parallel[3] test | grep -q 'no tests collected'; then
             echo "No parallel[3] tests found."
           else
-            mpiexec -n 3 python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[3] test
+            mpiexec -n 3 --use-hwthread-cpus python3 -m coverage run --parallel-mode --source=${{ github.event.repository.name }} -m pytest -v -m parallel[3] test
           fi
 
       - name: 'Generate coverage report'


### PR DESCRIPTION
Further to #114 and discussion in https://github.com/mesh-adaptation/animate/pull/175, it actually is possible to run parallel tests with 3 processes (should be possible with 4 as well). This PR adds them.

I also accidentally deleted `${{ inputs.test-command }}` in #114 so putting this back in now.
