### PR TITLE
Avoid workflow vulnerabilities

### DIFF
--- a/.github/workflows/publish_wiki.yml
+++ b/.github/workflows/publish_wiki.yml
@@ -11,14 +11,13 @@ concurrency:
   group: publish-wiki
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 jobs:
   publish-wiki:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - uses: Andrew-Chen-Wang/github-wiki-action@v4

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -8,8 +8,8 @@ on:
         required: false
         default: 'firedrake-parmmg'
         type: string
-      test-command:
-        description: 'Command to run before running tests'
+      animate-checkpoint-dirpath:
+        description: 'Path to the directory where checkpoints are stored'
         required: false
         type: string
 
@@ -25,6 +25,10 @@ jobs:
     container:
       image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
       options: --user root
+    env:
+      # Name of the repository that triggered the workflow
+      REPO_NAME: ${{ github.event.repository.name }}
+      ANIMATE_CHECKPOINT_DIR: ${{ inputs.animate-checkpoint-dirpath }}
 
     steps:
       - name: 'Check out the repo'
@@ -47,8 +51,7 @@ jobs:
       - name: 'Run tests'
         run: |
           . /home/firedrake/firedrake/bin/activate
-          ${{ inputs.test-command }}
           python $(which firedrake-clean)
           python -m coverage erase
-          python -m coverage run --source=${{ github.event.repository.name }} -m pytest -v --durations=20 test
+          python -m coverage run --source=${REPO_NAME} -m pytest -v --durations=20 test
           python -m coverage report -m

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -8,10 +8,6 @@ on:
         required: false
         default: 'firedrake-parmmg'
         type: string
-      animate-checkpoint-dirpath:
-        description: 'Path to the directory where checkpoints are stored'
-        required: false
-        type: string
 
 # Cancel jobs running if new commits are pushed
 concurrency:
@@ -28,7 +24,7 @@ jobs:
     env:
       # Name of the repository that triggered the workflow
       REPO_NAME: ${{ github.event.repository.name }}
-      ANIMATE_CHECKPOINT_DIR: ${{ inputs.animate-checkpoint-dirpath }}
+      ANIMATE_CHECKPOINT_DIR: ${{ github.workspace }}/.checkpoints
 
     steps:
       - name: 'Check out the repo'


### PR DESCRIPTION
Fixes for issues identified in #117:
- template injection (see https://woodruffw.github.io/zizmor/audits/#template-injection)
- excessive permissions (see https://woodruffw.github.io/zizmor/audits/#excessive-permissions) 

Edit: I completely removed the option to set the animate checkpoint directory via input to the workflow. I don't think we would want to change this from the default, so it was just overcomplicating things. So if you agree with this change, the Animate test workflow should go from this:
```
jobs:
  test_suite:
    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml
    with:
      test-command: |
        export ANIMATE_CHECKPOINT_DIR=$(pwd)/.checkpoints
```
to this:
```
jobs:
  test_suite:
    uses: mesh-adaptation/docs/.github/workflows/reusable_test_suite.yml
```
