### PR TITLE
Update docker images

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -25,9 +25,6 @@ jobs:
       # Name of the repository that triggered the workflow
       REPO_NAME: ${{ github.event.repository.name }}
       ANIMATE_CHECKPOINT_DIR: ${{ github.workspace }}/.checkpoints
-      # Allow executing mpiexec as root
-      OMPI_ALLOW_RUN_AS_ROOT: '1'
-      OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: '1'
       # Since we are root we need to set PYTHONPATH to find the installed packages
       PYTHONPATH: /home/firedrake/firedrake:/home/firedrake/animate:/home/firedrake/goalie:/home/firedrake/movement:/home/firedrake/UM2N:/home/firedrake/.local/lib/python3.12/site-packages
 
@@ -39,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: 'Install package'
-        run: pip install --break-system-packages -e .[dev]
+        run: pip install -e .[dev]
 
       - name: 'Lint'
         run: make lint

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -2,40 +2,70 @@
 # as well as Animate, Goalie, and Movement. Based off
 # https://github.com/firedrakeproject/firedrake/blob/master/docker/Dockerfile.vanilla
 
-FROM firedrakeproject/firedrake-env:latest
+FROM ubuntu:latest
 
+# ------------------------------
+# Environment setup
+# ------------------------------
+USER root
+
+# Use a more sane locale
+ENV LC_ALL=C.UTF-8
+# Avoid tzdata prompt (https://stackoverflow.com/questions/61388002/how-to-avoid-question-during-the-docker-build)
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/London
+ENV OMP_NUM_THREADS=1 
+ENV OPENBLAS_NUM_THREADS=1
+# Allow pip to install into system package locations without prompting
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+
+RUN apt-get update \
+    && apt-get -y install curl python3 python3-pip python3-venv sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Change the `ubuntu` user to `firedrake`
+RUN usermod -d /home/firedrake -m ubuntu \
+    && usermod -l firedrake ubuntu \
+    && groupmod -n firedrake ubuntu \
+    && usermod -aG sudo firedrake \
+    && echo "firedrake:docker" | chpasswd \
+    && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers \
+    && ldconfig
+
+WORKDIR /home/firedrake
+
+# ------------------------------
+# Install Firedrake dependencies
+# ------------------------------
 # Download firedrake-configure
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-configure
 
 # Install system dependencies
-RUN sudo apt-get update \
-    && sudo apt-get -y install \
-        $(python3 ./firedrake-configure --show-system-packages) \
-    && sudo rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get -y install \
+        $(python3 firedrake-configure --show-system-packages) \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install PETSc with additional packages for mesh adaptation. 
+# ------------------------------
+# Install PETSc with dependencies for mesh adaptation
+# ------------------------------
+# OpenMPI will complain if mpiexec is invoked as root unless these are set
+ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 # We set the compiler optimisation flags manually here to remove the default of
 # '-march=native' which is not suitable for Docker images.
 RUN git clone --depth 1 https://github.com/firedrakeproject/petsc.git \
     && cd petsc \
-    && python3 ../firedrake-configure --show-petsc-configure-options | \
-        sed "s/$/ \
-            --COPTFLAGS='-O3 -mtune=generic' \
-            --CXXOPTFLAGS='-O3 -mtune=generic' \
-            --FOPTFLAGS='-O3 -mtune=generic' \
-            --download-chaco \
-            --download-eigen \
-            --download-parmetis \
-            --download-mmg \
-            --download-parmmg/" | \
-        xargs -L1 ./configure --with-make-np=12 \
+    && python3 /home/firedrake/firedrake-configure --show-petsc-configure-options | \
+        sed "s/$/ --COPTFLAGS='-O3 -mtune=generic' --CXXOPTFLAGS='-O3 -mtune=generic' --FOPTFLAGS='-O3 -mtune=generic'/" | \
+        xargs -L1 ./configure --with-make-np=12 --download-chaco --download-eigen --download-parmetis --download-mmg --download-parmmg \
     && make \
     && make check \
     && rm -rf ./**/externalpackages \
     && rm -rf ./src/docs \
     && rm -f ./src/**/tutorials/output/* \
     && rm -f ./src/**/tests/output/* \
-    && cd ..
+    && cd - || exit
 
 # PETSc environment variables
 ENV PETSC_DIR=/home/firedrake/petsc PETSC_ARCH=arch-firedrake-default
@@ -46,17 +76,24 @@ ENV HDF5_MPI=ON
 ENV CC=mpicc CXX=mpicxx
 ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
-ENV PATH="/home/firedrake/.local/bin:$PATH" 
+ENV PATH="/home/firedrake/.local/bin:$PATH"
 
-# Install Firedrake; pass --break-system-packages since we are installing outside of a
-# virtual environment
-RUN pip install --break-system-packages --verbose --no-binary h5py --src . -e \
+# ------------------------------
+# Install Firedrake and mesh adaptation packages
+# ------------------------------
+USER firedrake
+
+# Install Firedrake
+RUN pip install --verbose --no-binary h5py --src . -e \
         git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[test]
+
+# Install Thetis
+RUN pip install --verbose --src . -e git+https://github.com/thetisproject/thetis.git#egg=thetis
 
 # Install Animate, Movement, Goalie and their dependencies
 RUN git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
-    pip install --break-system-packages -e animate[dev] && \
-    pip install --break-system-packages -e movement[dev] && \
-    pip install --break-system-packages -e goalie[dev]
+    pip install -e animate[dev] && \
+    pip install -e movement[dev] && \
+    pip install -e goalie[dev]

--- a/docker/Dockerfile.firedrake-um2n
+++ b/docker/Dockerfile.firedrake-um2n
@@ -25,10 +25,10 @@ RUN apt-get update && apt-get install -y \
 USER firedrake
 WORKDIR /home/firedrake
 
-RUN pip3 install --break-system-packages torch --index-url https://download.pytorch.org/whl/cpu && \
+RUN pip3 install torch --index-url https://download.pytorch.org/whl/cpu && \
     git clone https://github.com/mesh-adaptation/UM2N.git && \
-    python3 -m pip uninstall --break-system-packages cffconvert -y && \
-    python3 -m pip install --break-system-packages -e UM2N[dev]
+    python3 -m pip uninstall cffconvert -y && \
+    python3 -m pip install -e UM2N[dev]
 
 # NOTE: cffconvert is not currently used in UM2N and requires a conflicting
 # version of jsonschema with other dependencies.


### PR DESCRIPTION
There have been further changes to Firedrake's docker images. Previously we used `firedrake-env` as the base image, where they would install some system dependencies, set the `firedrake` user etc. But now they removed this and they use the `root` user, with packages being installed in `/opt`.

I think it's neater to keep it as it has been so far: be non-root and have packages installed in `/home/firedrake`. So this PR keeps things as they were: it just moves things from the old `firedrake-env` image to `firedrake-parmmg` and tidies things up a bit. 

The only change is that I install thetis, which I forgot to add in the previous PR.

- I tested the `firedrake-parmmg` image with with Goalie in https://github.com/mesh-adaptation/goalie/pull/299
- I tested the `firedrake-um2n` image locally and everything works well. The CI here fails because it uses the `firedrake-parmmg:latest` image which has still not been updated/pushed to ghcr.io. This will get updated properly when pushed to main branch.