### PR TITLE
Wiki addition: how to run containers with GPUs

### DIFF
--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -32,7 +32,7 @@ Passing the `--gpus` flag to `docker run` allows us to use GPUs inside container
 docker run -it --gpus all ghcr.io/mesh-adaptation/firedrake-parmmg:latest
 ```
 
-Once inside the container, check that your NVIDIA GPU has been detected by running `nvidia-smi` from the command line. If successful, information about your NVIDIA GPU should be displayed, similarly to this:
+Once inside the container, we should first check that the GPUs have been detected. For NVIDIA GPUs we may do so by running `nvidia-smi` from the command line. If successful, information about your NVIDIA GPUs should be displayed, similarly to this:
 ```
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 560.35.02              Driver Version: 560.94         CUDA Version: 12.6     |

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -24,6 +24,34 @@ docker run -it ghcr.io/mesh-adaptation/firedrake-parmmg:latest
 
 For more information on how to run docker containers, see the [official documentation](https://docs.docker.com/engine/containers/run/). For example, since all data inside a container is only accessible from inside the container, it is useful to create [filesystem mounts](https://docs.docker.com/engine/containers/run/#filesystem-mounts) to be able to access data from outside the container.
 
+
+### Using GPUs inside a container
+
+Passing the `--gpus` flag to `docker run` allows us to use GPUs inside containers (see [Docker documentation](https://docs.docker.com/reference/cli/docker/container/run/#gpus) for details). For example, to use all available GPUs, run the following:
+```
+docker run -it --gpus all ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+```
+
+Once inside the container, check that your NVIDIA GPU has been detected by running `nvidia-smi` from the command line. If successful, information about your NVIDIA GPU should be displayed, similarly to this:
+```
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.02              Driver Version: 560.94         CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 3060 Ti     On  |   00000000:01:00.0  On |                  N/A |
+|  0%   39C    P8             19W /  220W |    1274MiB /   8192MiB |      3%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+```
+
+Now you may proceed with installing GPU-supported software as normal. For example, to [install PyTorch](https://pytorch.org/get-started/locally/) with CUDA version 12.6 (as reported by `nvidia-smi` above), we may run:
+```
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+```
+
 ## Installing Mesh Adaptation modules
 
 The Mesh Adaptation packages can be installed through the following options, denoting the package of interest by `<PACKAGE>`.


### PR DESCRIPTION
Closes #84.

@jwallwork23 @acse-ej321 I added some more details for NVIDIA GPUs since that's what I have. Do either of you have an AMD GPU by any chance? If so, could you please test this and try to run the AMD equivalent of `nvidia-smi`? I think that should be `rocm-smi`.