### PR TITLE
Wiki: Clarify installation instructions; add PETSc `reconfigure` section

### DIFF
--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -22,7 +22,7 @@ If you have previously installed PETSc without the additional mesh adaptation pa
 ```
 cd $PETSC_DIR
 $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/reconfigure-$PETSC_ARCH.py --download-eigen --download-parmetis --download-mmg --download-parmmg
-make PETSC_DIR=/opt/petsc PETSC_ARCH=arch-firedrake-default all
+make PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} all
 ```
 
 ## Installing Mesh Adaptation modules

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -23,44 +23,6 @@ $PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/reconfigure-$PETSC_ARCH.py --download-eige
 make PETSC_DIR=/opt/petsc PETSC_ARCH=arch-firedrake-default all
 ```
 
-## Docker container approach
-
-A bespoke Firedrake Docker image exists and can be downloaded and run as an alternative to the above:
-```
-docker pull ghcr.io/mesh-adaptation/firedrake-parmmg:latest
-docker run -it ghcr.io/mesh-adaptation/firedrake-parmmg:latest
-```
-
-For more information on how to run docker containers, see the [official documentation](https://docs.docker.com/engine/containers/run/). For example, since all data inside a container is only accessible from inside the container, it is useful to create [filesystem mounts](https://docs.docker.com/engine/containers/run/#filesystem-mounts) to be able to access data from outside the container.
-
-
-### Using GPUs inside a container
-
-Passing the `--gpus` flag to `docker run` allows us to use GPUs inside containers (see [Docker documentation](https://docs.docker.com/reference/cli/docker/container/run/#gpus) for details). For example, to use all available GPUs, run the following:
-```
-docker run -it --gpus all ghcr.io/mesh-adaptation/firedrake-parmmg:latest
-```
-
-Once inside the container, we should first check that the GPUs have been detected. For NVIDIA GPUs we may do so by running `nvidia-smi` from the command line. If successful, information about your NVIDIA GPUs should be displayed, similarly to this:
-```
-+-----------------------------------------------------------------------------------------+
-| NVIDIA-SMI 560.35.02              Driver Version: 560.94         CUDA Version: 12.6     |
-|-----------------------------------------+------------------------+----------------------+
-| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
-| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
-|                                         |                        |               MIG M. |
-|=========================================+========================+======================|
-|   0  NVIDIA GeForce RTX 3060 Ti     On  |   00000000:01:00.0  On |                  N/A |
-|  0%   39C    P8             19W /  220W |    1274MiB /   8192MiB |      3%      Default |
-|                                         |                        |                  N/A |
-+-----------------------------------------+------------------------+----------------------+
-```
-
-Now you may proceed with installing GPU-supported software as normal. For example, to [install PyTorch](https://pytorch.org/get-started/locally/) with CUDA version 12.6 (as reported by `nvidia-smi` above), we may run:
-```
-pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
-```
-
 ## Installing Mesh Adaptation modules
 
 The Mesh Adaptation packages can be installed through the following options, denoting the package of interest by `<PACKAGE>`.
@@ -93,3 +55,40 @@ It is highly recommended to keep your Firedrake installation and Mesh Adaptation
 
 * To update Firedrake and PETSc, follow the [official Firedrake instructions](https://www.firedrakeproject.org/install.html#updating-firedrake) on how to do so.
 * To update Animate/Goalie/Movement, simply change directory to where each one is located (`cd /path/to/package`) and run `git pull`.
+
+## Docker container approach
+
+A bespoke Firedrake Docker image exists and can be downloaded and run as an alternative to the above:
+```
+docker pull ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+docker run -it ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+```
+
+For more information on how to run docker containers, see the [official documentation](https://docs.docker.com/engine/containers/run/). For example, since all data inside a container is only accessible from inside the container, it is useful to create [filesystem mounts](https://docs.docker.com/engine/containers/run/#filesystem-mounts) to be able to access data from outside the container.
+
+### Using GPUs inside a container
+
+Passing the `--gpus` flag to `docker run` allows us to use GPUs inside containers (see [Docker documentation](https://docs.docker.com/reference/cli/docker/container/run/#gpus) for details). For example, to use all available GPUs, run the following:
+```
+docker run -it --gpus all ghcr.io/mesh-adaptation/firedrake-parmmg:latest
+```
+
+Once inside the container, we should first check that the GPUs have been detected. For NVIDIA GPUs we may do so by running `nvidia-smi` from the command line. If successful, information about your NVIDIA GPUs should be displayed, similarly to this:
+```
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.02              Driver Version: 560.94         CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 3060 Ti     On  |   00000000:01:00.0  On |                  N/A |
+|  0%   39C    P8             19W /  220W |    1274MiB /   8192MiB |      3%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+```
+
+Now you may proceed with installing GPU-supported software as normal. For example, to [install PyTorch](https://pytorch.org/get-started/locally/) with CUDA version 12.6 (as reported by `nvidia-smi` above), we may run:
+```
+pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+```

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -1,6 +1,8 @@
 The following installation instructions assume a Linux or Windows Subsystem for Linux (WSL) operating system.
-The mesh adaptation modules are dependent on a custom setup for Firedrake with PETSc from either a [local installation](#local-firedrake-installation) or a [pre-built Docker image](#installing-firedrake-via-docker-image).
-Once Firedrake is installed (or if you already have a working installation), see the section on [installing Animate, Goalie, or Movement](#installing-animate-goalie-or-movement).
+
+The mesh adaptation modules are dependent on a custom setup for Firedrake with PETSc, as described in the [local installation](#local-firedrake-installation) section below. Once Firedrake is installed, see the section on [installing Animate, Goalie, or Movement](#installing-animate-goalie-or-movement).
+
+Alternatively, you may use a [pre-built Docker image](#docker-container-approach) with Animate, Goalie, Movement, and all their dependencies preinstalled and ready to use.
 
 ## Local Firedrake installation
 

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -53,7 +53,9 @@ It is highly recommended to keep your Firedrake installation and Mesh Adaptation
 
 ## Docker container approach
 
-A bespoke Firedrake Docker image exists and can be downloaded and run as an alternative to the above:
+We provide a bespoke Docker image with PETSc, Firedrake, Animate, Goalie, and Movement already preinstalled.
+
+The image can be downloaded and run as follows:
 ```
 docker pull ghcr.io/mesh-adaptation/firedrake-parmmg:latest
 docker run -it ghcr.io/mesh-adaptation/firedrake-parmmg:latest

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -27,27 +27,20 @@ make PETSC_DIR=/opt/petsc PETSC_ARCH=arch-firedrake-default all
 
 ## Installing Mesh Adaptation modules
 
-The Mesh Adaptation packages can be installed through the following options, denoting the package of interest by `<PACKAGE>`.
-In both cases, make sure that you have activated the Python virtual environment that was created when you installed Firedrake.
-Ensure that you have activated the Python virtual environment associated with your Firedrake installation before following the steps below:
+The Mesh Adaptation packages Animate, Goalie, and Movement are installed as follows, denoting the package of interest by `<PACKAGE>`.
+First, ensure that you have activated the Python virtual environment associated with your Firedrake installation:
 ```
 source /path/to/venv/bin/activate
 ```
 
-### Cloning via HTTPS
-
+Then clone the `<PACKAGE>` repository using [your preferred method](https://docs.github.com/en/get-started/git-basics/about-remote-repositories). For example, cloning with HTTPS URL is done as follows:
 ```
 git clone https://github.com/mesh-adaptation/<PACKAGE>.git
-cd <PACKAGE>
-make install
 ```
 
-### Cloning via SSH
-
+Once cloned, the package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
 ```
-git@github.com:mesh-adaptation/<PACKAGE>.git
-cd <PACKAGE>
-make install
+python3 -m pip install <PACKAGE>
 ```
 
 ## Updating

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -40,7 +40,7 @@ git clone https://github.com/mesh-adaptation/<PACKAGE>.git
 
 Once cloned, the package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
 ```
-python3 -m pip install <PACKAGE>
+python3 -m pip install -e <PACKAGE>
 ```
 
 ## Updating

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -14,6 +14,15 @@ To use the mesh adaptation modules, we can install system dependencies (step 1) 
 python3 ../firedrake-configure --show-petsc-configure-options | xargs -L1 ./configure --download-eigen --download-parmetis --download-mmg --download-parmmg
 ```
 
+### Reconfiguring an existing installation
+
+If you have previously installed PETSc without the additional mesh adaptation packages listed above, you can install them using PETSc's [reconfigure](https://petsc.org/release/install/multibuild/#reconfigure) script as follows:
+```
+cd $PETSC_DIR
+$PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/reconfigure-$PETSC_ARCH.py --download-eigen --download-parmetis --download-mmg --download-parmmg
+make PETSC_DIR=/opt/petsc PETSC_ARCH=arch-firedrake-default all
+```
+
 ## Docker container approach
 
 A bespoke Firedrake Docker image exists and can be downloaded and run as an alternative to the above:


### PR DESCRIPTION
I think it would be good to further expand and clarify the installation instructions in the wiki:
- I added a section on how to reconfigure an existing PETSc installation. I think this is useful since I assume that many users will already have an existing installation
- I clearly separated the "local install" and "Docker" approaches and their differences. I thought that it was slightly confusing in its current state.
  - I now explicitly state that the Docker image has everything pre-installed and ready to use.
  - I put the section on Docker at the very end, so that it is not intertwined with the 'local installation' approach
- I simplified the 'Installing Mesh Adaptation modules' section with various minor changes (will leave comments on specific changes)