### PR TITLE
Fix docker build

### DIFF
--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -57,8 +57,8 @@ ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 RUN git clone --depth 1 --branch $(python3 firedrake-configure --show-petsc-version) https://gitlab.com/petsc/petsc.git \
     && cd petsc \
     && python3 /home/firedrake/firedrake-configure --show-petsc-configure-options | \
-        sed "s/$/ --COPTFLAGS='-O3 -mtune=generic' --CXXOPTFLAGS='-O3 -mtune=generic' --FOPTFLAGS='-O3 -mtune=generic'/" | \
-        xargs -L1 ./configure --with-make-np=4 --download-eigen --download-parmetis --download-mmg --download-parmmg \
+        sed "s/-march=native -mtune=native/-mtune=generic/g" | \
+        xargs -L1 ./configure --with-make-np=4 --download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg \
     && make \
     && make check \
     && rm -rf ./**/externalpackages \

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -32,26 +32,23 @@ RUN usermod -d /home/firedrake -m ubuntu \
     && echo "firedrake ALL=(ALL) NOPASSWD: ALL" >>/etc/sudoers \
     && ldconfig
 
-WORKDIR /home/firedrake
-
 # ------------------------------
 # Install Firedrake dependencies
 # ------------------------------
 # Download firedrake-configure
+
+USER firedrake
+WORKDIR /home/firedrake
 RUN curl -O https://raw.githubusercontent.com/firedrakeproject/firedrake/master/scripts/firedrake-configure
 
+USER root
 # Install system dependencies
 RUN apt-get update \
     && apt-get -y install \
         $(python3 firedrake-configure --show-system-packages) \
     && rm -rf /var/lib/apt/lists/*
 
-# ------------------------------
-# Install PETSc with dependencies for mesh adaptation
-# ------------------------------
-# OpenMPI will complain if mpiexec is invoked as root unless these are set
-ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-
+USER firedrake
 # We set the compiler optimisation flags manually here to remove the default of
 # '-march=native' which is not suitable for Docker images.
 RUN git clone --depth 1 --branch $(python3 firedrake-configure --show-petsc-version) https://gitlab.com/petsc/petsc.git \
@@ -78,14 +75,23 @@ ENV CFLAGS="-mtune=generic" CPPFLAGS="-mtune=generic"
 ENV MPICC=$CC
 ENV PATH="/home/firedrake/.local/bin:$PATH"
 
+# Hotfix for petsc4py build, see https://gitlab.com/petsc/petsc/-/issues/1759
+RUN echo 'Cython<3.1' > constraints.txt
+ENV PIP_CONSTRAINT=constraints.txt
+
+RUN pip cache remove petsc4py
+RUN pip install "$PETSC_DIR"/src/binding/petsc4py
+RUN git clone https://github.com/firedrakeproject/firedrake.git
+RUN pip install -r ./firedrake/requirements-build.txt
+
+
 # ------------------------------
 # Install Firedrake and mesh adaptation packages
 # ------------------------------
-USER firedrake
+
 
 # Install Firedrake
-RUN pip install --verbose --no-binary h5py --src . -e \
-        git+https://github.com/firedrakeproject/firedrake.git#egg=firedrake[check]
+RUN pip install --no-build-isolation --no-binary h5py -e firedrake/[check]
 
 # Install Thetis
 RUN pip install --verbose --src . -e git+https://github.com/thetisproject/thetis.git#egg=thetis


### PR DESCRIPTION
Closes #131
Following https://github.com/firedrakeproject/firedrake/commit/c48cadfb503ddfcb9ff5a7ffa28605e2fc5dc95e hdf5 and others now use Ubuntu system packages, which means we have to be careful to not clobber the [CXX|C|F]OPTFLAGS suggested by firedrake-configure
Also it appears we now need to explicitly --download-metis for parmetis (which depends on it) to build.
