### PR TITLE
fix install instructions for metis

### DIFF
--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -13,7 +13,7 @@ As described on the [Firedrake installation page](https://www.firedrakeproject.o
 
 To use the mesh adaptation modules, we can install system dependencies (step 1) and Firedrake (step 3) exactly as described, but we must [customise the PETSc installation](https://www.firedrakeproject.org/install.html#id29) (step 2) to install additional packages: Eigen, ParMETIS, MMG, and ParMMG. We do that simply by passing the `--download-<PACKAGE>` flags when running PETSc `configure`:
 ```
-python3 ../firedrake-configure --show-petsc-configure-options | xargs -L1 ./configure --download-eigen --download-parmetis --download-mmg --download-parmmg
+python3 ../firedrake-configure --show-petsc-configure-options | xargs -L1 ./configure --download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg
 ```
 
 ### Reconfiguring an existing installation
@@ -21,7 +21,7 @@ python3 ../firedrake-configure --show-petsc-configure-options | xargs -L1 ./conf
 If you have previously installed PETSc without the additional mesh adaptation packages listed above, you can install them using PETSc's [reconfigure](https://petsc.org/release/install/multibuild/#reconfigure) script as follows:
 ```
 cd $PETSC_DIR
-$PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/reconfigure-$PETSC_ARCH.py --download-eigen --download-parmetis --download-mmg --download-parmmg
+$PETSC_DIR/$PETSC_ARCH/lib/petsc/conf/reconfigure-$PETSC_ARCH.py --download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg
 make PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} all
 ```
 


### PR DESCRIPTION
When I follow the instructions for a fresh install, I get an error in configuring parmetis. The error went away when I added `--download-metis` first. The instructions already have both packages for updating an existing PETSc install.