### PR TITLE
Reinstate OMPI_ALLOW_RUN_AS_ROOT=1

### DIFF
--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -48,7 +48,12 @@ RUN apt-get update \
         $(python3 firedrake-configure --show-system-packages) \
     && rm -rf /var/lib/apt/lists/*
 
-USER firedrake
+# ------------------------------
+# Install PETSc with dependencies for mesh adaptation
+# ------------------------------
+# OpenMPI will complain if mpiexec is invoked as root unless these are set
+ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
 # We set the compiler optimisation flags manually here to remove the default of
 # '-march=native' which is not suitable for Docker images.
 RUN git clone --depth 1 --branch $(python3 firedrake-configure --show-petsc-version) https://gitlab.com/petsc/petsc.git \


### PR DESCRIPTION
I removed this because I thought it was only needed for the petsc build which we used to build as root, but is now build as user firedrake just like firedrake itself. Turns out the CI tests actually switch back to --user=root for running the tests for some reason.
