### PR TITLE
Switch to scotch v7.0.8a

### DIFF
--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -56,11 +56,13 @@ ENV OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 # We set the compiler optimisation flags manually here to remove the default of
 # '-march=native' which is not suitable for Docker images.
+# We use a prerelease version of ptscotch to avoid crashing on fortify source checks
+# see: https://gitlab.com/petsc/petsc/-/issues/1762
 RUN git clone --depth 1 --branch $(python3 firedrake-configure --show-petsc-version) https://gitlab.com/petsc/petsc.git \
     && cd petsc \
     && python3 /home/firedrake/firedrake-configure --show-petsc-configure-options | \
         sed "s/-march=native -mtune=native/-mtune=generic/g" | \
-        xargs -L1 ./configure --with-make-np=4 --download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg \
+        xargs -L1 ./configure --with-make-np=4 --download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg --download-ptscotch=https://joliv.et/scotch_7.0.8alpha1.tar.gz \
     && make \
     && make check \
     && rm -rf ./**/externalpackages \


### PR DESCRIPTION
Related to https://github.com/mesh-adaptation/animate/issues/136

As discussed in https://github.com/mesh-adaptation/animate/issues/136 the MMG3d failures (serial or serialised parallel) are due to failing "source fortification" checks in scotch which is used by mmgd3d. Scotch is known unsafe for these and they have been switched off in versions >=7.0.7 As advised in https://gitlab.com/petsc/petsc/-/issues/1762 we can switch to a v7.0.8 prerelease to deal with this.

I've tried this out here: https://github.com/mesh-adaptation/animate/pull/184 (using a docker build of this PR that I pushed somewhere else) and it indeed seems to fix all mmg3d failures.