### PR TITLE
Manually check inputs to safely ignore template injection risk

### DIFF
--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: 'Check out Dockerfile'
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           repository: ${{ inputs.dockerfile-repo }}
           sparse-checkout: ${{ inputs.dockerfile-path }}
           sparse-checkout-cone-mode: false
@@ -52,8 +53,12 @@ jobs:
       - name: 'Load previously built Docker image'
         if: ${{ inputs.load-docker-image-artifact != null }}
         run: |
-          docker image load -i images/${{ inputs.load-docker-image-artifact }}.tar
-          echo ${{ inputs.load-docker-image-artifact }}.tar > .dockerignore
+          if [[ ! "${{ inputs.save-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,11}$ ]]; then
+            echo "Invalid input for load-docker-image-artifact"
+            exit 1
+          fi
+          docker image load -i "images/${{ inputs.load-docker-image-artifact }}.tar"
+          echo "${{ inputs.load-docker-image-artifact }}.tar" > .dockerignore
 
       - name: 'Set up Docker buildx'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3
@@ -89,8 +94,12 @@ jobs:
       - name: 'Save Docker image'
         if: ${{ inputs.save-docker-image-artifact != null }}
         run: |
+          if [[ ! "${{ inputs.save-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,11}$ ]]; then
+            echo "Invalid input for load-docker-image-artifact"
+            exit 1
+          fi
           mkdir -p images
-          docker image save -o images/${{ inputs.save-docker-image-artifact }}.tar ${{ inputs.docker-image-tag }}
+          docker image save -o "images/${{ inputs.save-docker-image-artifact }}.tar" ${{ inputs.docker-image-tag }}
 
       - name: 'Upload saved Docker image as artifact'
         if: ${{ inputs.save-docker-image-artifact != null }}

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  template-injection:
+    ignore:
+      # Ignore template injection in cases where we manually check inputs
+      - reusable_docker_build.yml:56
+      - reusable_docker_build.yml:60
+      - reusable_docker_build.yml:97
+      - reusable_docker_build.yml:102


### PR DESCRIPTION
Merges into #155.

Zizmor currently reports that the workflow in #155 currently has template injection vulnerabilities. This PR fixes those by manually checking the strings conform to the expected pattern and then ignoring those specific lines in a `zizmor.yml` config file.