### PR TITLE
Install submodules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# will be requested for review when someone opens a pull request.
+*      @joewallwork @stephankramer
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies specified file types, only that owner will be
+# requested for a review, not the global owner(s).
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -60,7 +60,7 @@ jobs:
             exit 1
           fi
           docker image load -i "images/${{ inputs.load-docker-image-artifact }}.tar"
-          rm "${{ inputs.load-docker-image-artifact }}.tar"
+          rm "images/${{ inputs.load-docker-image-artifact }}.tar"
 
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -60,7 +60,7 @@ jobs:
             exit 1
           fi
           docker image load -i "images/${{ inputs.load-docker-image-artifact }}.tar"
-          echo "${{ inputs.load-docker-image-artifact }}.tar" > .dockerignore
+          rm "${{ inputs.load-docker-image-artifact }}.tar"
 
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435  # v3

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Configure submodules and install the package
         run: |
+          git config --global --add safe.directory /__w/animate/animate
+          git config --global --add safe.directory /__w/goalie/goalie
+          git config --global --add safe.directory /__w/movement/movement
+          git config --global --add safe.directory /__w/UM2N/UM2N
           git submodule init
           git submodule update
           pip install -e .[dev]

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -43,6 +43,7 @@ jobs:
           git config --global --add safe.directory /__w/UM2N/UM2N
           git submodule init
           git submodule update
+          pip uninstall ${REPO_NAME} -y || true
           pip install -e .[dev]
 
       - run: make lint

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -35,7 +35,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: pip install -e .[dev]
+      - name: Configure submodules and install the package
+        run: |
+          git submodule init
+          git submodule update
+          pip install -e .[dev]
 
       - run: make lint
 

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -38,7 +38,14 @@ Then clone the `<PACKAGE>` repository using [your preferred method](https://docs
 git clone https://github.com/mesh-adaptation/<PACKAGE>.git
 ```
 
-Once cloned, the package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
+Once cloned, the package submodules must be initialised and updated:
+```
+cd <PACKAGE>
+git submodule init
+git submodule update
+```
+
+The package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
 ```
 python3 -m pip install -e <PACKAGE>
 ```

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -4,6 +4,7 @@ rules:
       # Ignore template injection in cases where we manually check inputs
       - reusable_docker_build.yml:56
       - reusable_docker_build.yml:60
+      - reusable_docker_build.yml:63
       - reusable_docker_build.yml:104
       - reusable_docker_build.yml:109
   unpinned-images:


### PR DESCRIPTION
Supersedes #164.

In this PR, we instead set up submodules when installing the package in the CI. If the package has no submodules then this should still work. Once `adapt_common` is added as a submodule, that will then be part of the install.

Also adding a `CODEOWNERS` file while I'm at it.