### PR TITLE
Account for `adapt_common`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# will be requested for review when someone opens a pull request.
+*      @joewallwork @stephankramer
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies specified file types, only that owner will be
+# requested for a review, not the global owner(s).
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -35,7 +35,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: pip install -e .[dev]
+      - name: Configure submodules and install the package
+        run: |
+          git submodule init
+          git submodule update
+          pip install -e .[dev]
 
       - run: make lint
 

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -37,8 +37,14 @@ jobs:
 
       - name: Configure submodules and install the package
         run: |
+          git config --global --add safe.directory /__w/adapt_common/adapt_common
+          git config --global --add safe.directory /__w/animate/animate
+          git config --global --add safe.directory /__w/goalie/goalie
+          git config --global --add safe.directory /__w/movement/movement
+          git config --global --add safe.directory /__w/UM2N/UM2N
           git submodule init
           git submodule update
+          pip uninstall ${REPO_NAME} -y || true
           pip install -e .[dev]
 
       - run: make lint

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -7,10 +7,12 @@ WORKDIR /root
 # Install Thetis
 RUN pip install --verbose --src . -e git+https://github.com/thetisproject/thetis.git#egg=thetis
 
-# Install Animate, Movement, Goalie and their dependencies
-RUN git clone https://github.com/mesh-adaptation/animate.git && \
+# Install adapt_common, Animate, Movement, Goalie and their dependencies
+RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
+    git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
+    pip install -e adapt_common[dev] && \
     pip install -e animate[dev] && \
     pip install -e movement[dev] && \
     pip install -e goalie[dev]

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -27,11 +27,15 @@ make PETSC_DIR=${PETSC_DIR} PETSC_ARCH=${PETSC_ARCH} all
 
 ## Installing Mesh Adaptation modules
 
-The Mesh Adaptation packages Animate, Goalie, and Movement are installed as follows, denoting the package of interest by `<PACKAGE>`.
 First, ensure that you have activated the Python virtual environment associated with your Firedrake installation:
 ```
 source /path/to/venv/bin/activate
 ```
+
+Next, install the `adapt_common` package, which provides common functionality
+for the other Mesh Adaptation packages.
+This and the other Mesh Adaptation packages - Animate, Goalie, and Movement -
+are installed as follows, denoting the package of interest by `<PACKAGE>`.
 
 Then clone the `<PACKAGE>` repository using [your preferred method](https://docs.github.com/en/get-started/git-basics/about-remote-repositories). For example, cloning with HTTPS URL is done as follows:
 ```


### PR DESCRIPTION
This PR accounts for `adapt_common` by:
1. Adding it to the Docker container
2. Initialising and updating submodules in the reusable test suite
3. Mentioning it in the docs

This PR also adds the same `CODEOWNERS` file as in the code repos.