### PR TITLE
Add Docker build workflow on `release`

### DIFF
--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -42,8 +42,8 @@ jobs:
       # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
       # which contains a build of petsc+firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
-      dockerfile-branch: 'main'
       dockerfile-path: 'docker/Dockerfile.vanilla'
+      dockerfile-branch: 'main'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base'
 
@@ -56,6 +56,7 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
+      dockerfile-branch: 'main'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base'
       save-docker-image-artifact: 'firedrake-parmmg'

--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -39,11 +39,12 @@ jobs:
       packages: write
     uses: ./.github/workflows/reusable_docker_build.yml
     with:
-      # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
-      # which contains a build of petsc+firedrake with (Par)Mmg libraries included
+      # use Dockerfile.vanilla from Firedrake to build firedrake-parmmg-base image
+      # which contains a build of PETSc+Firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
       dockerfile-path: 'docker/Dockerfile.vanilla'
       dockerfile-branch: 'main'
+      firedrake-branch: 'main'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base'
 
@@ -57,6 +58,7 @@ jobs:
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
       dockerfile-branch: 'main'
+      firedrake-branch: 'main'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base'
       save-docker-image-artifact: 'firedrake-parmmg'

--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -42,10 +42,10 @@ jobs:
       # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
       # which contains a build of petsc+firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
+      dockerfile-branch: 'main'
       dockerfile-path: 'docker/Dockerfile.vanilla'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base'
-      firedrake-branch: 'main'
 
   docker_parmmg:
     permissions:
@@ -59,7 +59,6 @@ jobs:
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base'
       save-docker-image-artifact: 'firedrake-parmmg'
-      firedrake-branch: 'main'
 
   docker_um2n:
     permissions:
@@ -72,4 +71,3 @@ jobs:
       dockerfile-path: 'docker/Dockerfile.firedrake-um2n'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-um2n:latest'
       load-docker-image-artifact: 'firedrake-parmmg'
-      firedrake-branch: 'main'

--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -57,7 +57,6 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
-      dockerfile-branch: 'main'
       firedrake-branch: 'main'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base'

--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -1,12 +1,11 @@
-name: Build Firedrake Docker container with (Par)Mmg
+name: Build Firedrake Docker container with (Par)Mmg (main)
 
 on:
   # Check that Docker build succeeds when these files get changed in an open PR
   pull_request:
     paths:
       - '.github/workflows/reusable_docker_build.yml'
-      - '.github/workflows/docker_firedrake-parmmg.yml'
-      - '.github/workflows/reusable_test_suite.yml'
+      - '.github/workflows/docker_firedrake-parmmg_main.yml'
       - 'docker/Dockerfile.firedrake-parmmg'
       - 'docker/Dockerfile.firedrake-um2n'
 
@@ -16,8 +15,7 @@ on:
       - main
     paths:
       - '.github/workflows/reusable_docker_build.yml'
-      - '.github/workflows/docker_firedrake-parmmg.yml'
-      - '.github/workflows/reusable_test_suite.yml'
+      - '.github/workflows/docker_firedrake-parmmg_main.yml'
       - 'docker/Dockerfile.firedrake-parmmg'
       - 'docker/Dockerfile.firedrake-um2n'
 
@@ -47,6 +45,7 @@ jobs:
       dockerfile-path: 'docker/Dockerfile.vanilla'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base'
+      firedrake-branch: 'main'
 
   docker_parmmg:
     permissions:
@@ -60,6 +59,7 @@ jobs:
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base'
       save-docker-image-artifact: 'firedrake-parmmg'
+      firedrake-branch: 'main'
 
   docker_um2n:
     permissions:
@@ -72,3 +72,4 @@ jobs:
       dockerfile-path: 'docker/Dockerfile.firedrake-um2n'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-um2n:latest'
       load-docker-image-artifact: 'firedrake-parmmg'
+      firedrake-branch: 'main'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -56,5 +56,6 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
+      dockerfile-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-release:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -57,7 +57,7 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
-      dockerfile-branch: 'main'
+      dockerfile-branch: '156_main-release'
       firedrake-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:release'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -42,6 +42,7 @@ jobs:
       # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
       # which contains a build of petsc+firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
+      dockerfile-path: 'docker/Dockerfile.vanilla'
       dockerfile-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base-release:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -44,7 +44,7 @@ jobs:
       dockerfile-repo: 'firedrakeproject/firedrake'
       dockerfile-path: 'docker/Dockerfile.vanilla'
       dockerfile-branch: 'release'
-      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base-release:latest'
+      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:release'
       save-docker-image-artifact: 'firedrake-parmmg-base-release'
 
   docker_parmmg:
@@ -57,5 +57,5 @@ jobs:
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
       dockerfile-branch: 'release'
-      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-release:latest'
+      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:release'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -42,10 +42,9 @@ jobs:
       # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
       # which contains a build of petsc+firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
-      dockerfile-path: 'docker/Dockerfile.vanilla'
+      dockerfile-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base-release:latest'
       save-docker-image-artifact: 'firedrake-parmmg-base-release'
-      firedrake-branch: 'release'
 
   docker_parmmg:
     permissions:
@@ -58,4 +57,3 @@ jobs:
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-release:latest'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'
-      firedrake-branch: 'release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -1,0 +1,61 @@
+name: Build Firedrake Docker container with (Par)Mmg (release)
+
+on:
+  # Check that Docker build succeeds when these files get changed in an open PR
+  pull_request:
+    paths:
+      - '.github/workflows/reusable_docker_build.yml'
+      - '.github/workflows/docker_firedrake-parmmg_release.yml'
+      - 'docker/Dockerfile.firedrake-parmmg'
+      - 'docker/Dockerfile.firedrake-um2n'
+
+  # Build and push the Docker container when these files get changed on the main branch
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/reusable_docker_build.yml'
+      - '.github/workflows/docker_firedrake-parmmg_release.yml'
+      - 'docker/Dockerfile.firedrake-parmmg'
+      - 'docker/Dockerfile.firedrake-um2n'
+
+  # Run test suite at 1AM on the first of the month
+  schedule:
+    - cron: '0 1 1 * *'
+
+  # Manually trigger the workflow
+  workflow_dispatch:
+
+permissions: {}
+
+# Stop the workflow if a new run is requested
+concurrency:
+  group: $${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker_base:
+    permissions:
+      packages: write
+    uses: ./.github/workflows/reusable_docker_build.yml
+    with:
+      # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
+      # which contains a build of petsc+firedrake with (Par)Mmg libraries included
+      dockerfile-repo: 'firedrakeproject/firedrake'
+      dockerfile-path: 'docker/Dockerfile.vanilla'
+      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base-release:latest'
+      save-docker-image-artifact: 'firedrake-parmmg-base-release'
+      firedrake-branch: 'release'
+
+  docker_parmmg:
+    permissions:
+      packages: write
+    uses: ./.github/workflows/reusable_docker_build.yml
+    needs: docker_base
+    with:
+      # starting from firedrake-parmmg-base, build firedrake-parmmg image
+      # which includes Animate, Movement, Goalie, and Thetis packages
+      dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
+      docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-release:latest'
+      load-docker-image-artifact: 'firedrake-parmmg-base-release'
+      firedrake-branch: 'release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -39,11 +39,12 @@ jobs:
       packages: write
     uses: ./.github/workflows/reusable_docker_build.yml
     with:
-      # use Dockerfile.vanilla from firedrake to build firedrake-parmmg-base image
-      # which contains a build of petsc+firedrake with (Par)Mmg libraries included
+      # use Dockerfile.vanilla from Firedrake to build firedrake-parmmg-base image
+      # which contains a build of PETSc+Firedrake with (Par)Mmg libraries included
       dockerfile-repo: 'firedrakeproject/firedrake'
       dockerfile-path: 'docker/Dockerfile.vanilla'
       dockerfile-branch: 'release'
+      firedrake-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg-base:release'
       save-docker-image-artifact: 'firedrake-parmmg-base-release'
 
@@ -56,6 +57,7 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
-      dockerfile-branch: 'release'
+      dockerfile-branch: 'main'
+      firedrake-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:release'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -57,7 +57,6 @@ jobs:
       # starting from firedrake-parmmg-base, build firedrake-parmmg image
       # which includes Animate, Movement, Goalie, and Thetis packages
       dockerfile-path: 'docker/Dockerfile.firedrake-parmmg'
-      dockerfile-branch: '156_main-release'
       firedrake-branch: 'release'
       docker-image-tag: 'ghcr.io/mesh-adaptation/firedrake-parmmg:release'
       load-docker-image-artifact: 'firedrake-parmmg-base-release'

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -11,7 +11,7 @@ on:
       dockerfile-branch:
         description: 'Branch of repo containing Dockerfile'
         required: false
-        default: $${{ github.head }}
+        default: $${{ github.head_ref }}
         type: string
       dockerfile-path:
         description: 'Path to the Dockerfile to be built'

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -99,8 +99,6 @@ jobs:
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
           tags: ${{ inputs.docker-image-tag }}
-          # Build arguments are only used by Firedrake's Dockerfile.vanilla,
-          # in which case the branch to build is the same as the Dockerfile is from
           build-args: |
             ARCH=default
             BRANCH=${{ inputs.firedrake-branch }}

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -8,6 +8,11 @@ on:
         default: ${{ github.repository }}
         required: false
         type: string
+      dockerfile-branch:
+        description: 'Branch of repo containing Dockerfile'
+        required: false
+        default: $${{ github.head }}
+        type: string
       dockerfile-path:
         description: 'Path to the Dockerfile to be built'
         required: true
@@ -23,10 +28,6 @@ on:
       load-docker-image-artifact:
         description: 'Before the build, load this image as artifact'
         required: false
-        type: string
-      firedrake-branch:
-        description: 'Firedrake branch to build'
-        required: true
         type: string
 
 permissions: {}
@@ -45,6 +46,7 @@ jobs:
         with:
           persist-credentials: false
           repository: ${{ inputs.dockerfile-repo }}
+          ref: $${{ inputs.dockerfile-branch }}
           sparse-checkout: ${{ inputs.dockerfile-path }}
           sparse-checkout-cone-mode: false
           path: .
@@ -92,9 +94,11 @@ jobs:
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
           tags: ${{ inputs.docker-image-tag }}
+          # build-args are only used by firedrake's Dockerfile.vanilla
+          # in which case the branch to build is the same as the Dockerfile is from
           build-args: |
             ARCH=default
-            BRANCH=${{ inputs.firedrake-branch }}
+            BRANCH=${{ inputs.dockerfile-branch }}
             PETSC_EXTRA_ARGS=--download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg --download-ptscotch
 
       - name: Save Docker image

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -11,7 +11,7 @@ on:
       dockerfile-branch:
         description: 'Branch of repo containing Dockerfile'
         required: false
-        default: $${{ github.head_ref }}
+        default: ${{ github.head_ref }}
         type: string
       dockerfile-path:
         description: 'Path to the Dockerfile to be built'
@@ -46,7 +46,7 @@ jobs:
         with:
           persist-credentials: false
           repository: ${{ inputs.dockerfile-repo }}
-          ref: $${{ inputs.dockerfile-branch }}
+          ref: ${{ inputs.dockerfile-branch }}
           sparse-checkout: ${{ inputs.dockerfile-path }}
           sparse-checkout-cone-mode: false
           path: .

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Load previously built Docker image
         if: ${{ inputs.load-docker-image-artifact != null }}
         run: |
-          if [[ ! "${{ inputs.load-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,11}$ ]]; then
+          if [[ ! "${{ inputs.load-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,19}$ ]]; then
             echo "Invalid input for load-docker-image-artifact"
             exit 1
           fi
@@ -104,7 +104,7 @@ jobs:
       - name: Save Docker image
         if: ${{ inputs.save-docker-image-artifact != null }}
         run: |
-          if [[ ! "${{ inputs.save-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,11}$ ]]; then
+          if [[ ! "${{ inputs.save-docker-image-artifact }}" =~ ^firedrake-[a-z-]{1,19}$ ]]; then
             echo "Invalid input for save-docker-image-artifact"
             exit 1
           fi

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -24,6 +24,10 @@ on:
         description: 'Before the build, load this image as artifact'
         required: false
         type: string
+      firedrake-branch:
+        description: 'Firedrake branch to build'
+        required: true
+        type: string
 
 permissions: {}
 
@@ -90,7 +94,7 @@ jobs:
           tags: ${{ inputs.docker-image-tag }}
           build-args: |
             ARCH=default
-            BRANCH=main
+            BRANCH=${{ inputs.firedrake-branch }}
             PETSC_EXTRA_ARGS=--download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg --download-ptscotch
 
       - name: Save Docker image

--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ${{ github.head_ref }}
         type: string
+      firedrake-branch:
+        description: 'Branch to pass as the BRANCH build argument when building the Docker container'
+        required: false
+        default: ${{ github.head_ref }}
+        type: string
       dockerfile-path:
         description: 'Path to the Dockerfile to be built'
         required: true
@@ -94,11 +99,11 @@ jobs:
           no-cache: true
           file: ${{ inputs.dockerfile-path }}
           tags: ${{ inputs.docker-image-tag }}
-          # build-args are only used by firedrake's Dockerfile.vanilla
+          # Build arguments are only used by Firedrake's Dockerfile.vanilla,
           # in which case the branch to build is the same as the Dockerfile is from
           build-args: |
             ARCH=default
-            BRANCH=${{ inputs.dockerfile-branch }}
+            BRANCH=${{ inputs.firedrake-branch }}
             PETSC_EXTRA_ARGS=--download-eigen --download-metis --download-parmetis --download-mmg --download-parmmg --download-ptscotch
 
       - name: Save Docker image

--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -6,7 +6,7 @@ on:
       docker-image:
         description: 'Name of the Firedrake Docker image to use'
         required: false
-        default: 'firedrake-parmmg'
+        default: 'firedrake-parmmg:latest'
         type: string
 
 concurrency:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     container:
-      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}:latest
+      image: ghcr.io/mesh-adaptation/${{ inputs.docker-image }}
       options: --user root
     env:
       # Name of the repository that triggered the workflow

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -2,6 +2,9 @@
 # and with the main mesh-adaptation packages installed in /root
 FROM ghcr.io/mesh-adaptation/firedrake-parmmg-base:latest
 
+# Which branch is to be used across all repositories?
+ARG BRANCH="main"
+
 WORKDIR /root
 
 # Install Thetis
@@ -12,6 +15,9 @@ RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
     git clone https://github.com/mesh-adaptation/animate.git && \
     git clone https://github.com/mesh-adaptation/movement.git && \
     git clone https://github.com/mesh-adaptation/goalie.git && \
+    cd animate && git checkout ${BRANCH} && cd .. && \
+    cd movement && git checkout ${BRANCH} && cd .. && \
+    cd goalie && git checkout ${BRANCH} && cd .. && \
     cd animate && git submodule init && git submodule update && cd .. && \
     cd movement && git submodule init && git submodule update && cd .. && \
     pip install -e adapt_common[dev] && \

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -5,8 +5,8 @@ rules:
       - reusable_docker_build.yml:69
       - reusable_docker_build.yml:73
       - reusable_docker_build.yml:74
-      - reusable_docker_build.yml:112
-      - reusable_docker_build.yml:117
+      - reusable_docker_build.yml:110
+      - reusable_docker_build.yml:115
   unpinned-images:
     ignore:
       # Ignore unpinned images for trusted Docker images

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -2,11 +2,11 @@ rules:
   template-injection:
     ignore:
       # Ignore template injection in cases where we manually check inputs
-      - reusable_docker_build.yml:56
-      - reusable_docker_build.yml:60
-      - reusable_docker_build.yml:63
-      - reusable_docker_build.yml:104
-      - reusable_docker_build.yml:109
+      - reusable_docker_build.yml:69
+      - reusable_docker_build.yml:73
+      - reusable_docker_build.yml:74
+      - reusable_docker_build.yml:112
+      - reusable_docker_build.yml:117
   unpinned-images:
     ignore:
       # Ignore unpinned images for trusted Docker images


### PR DESCRIPTION
Closes #156.

This PR sets up a separate workflow for building and pushing a Docker build for the `release` branch. It passes `--build-arg BRANCH=release` to the Firedrake Docker build. It's triggered on updates to the workflow and on a monthly basis.