### PR TITLE
Use editable pip install to fix testing of cython packages

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -45,7 +45,7 @@ jobs:
           git submodule init
           git submodule update
           pip uninstall ${REPO_NAME} -y || true
-          pip install --no-build-isolation .[dev]
+          pip install --no-build-isolation -e .[dev]
 
       - run: make lint
 


### PR DESCRIPTION
In #172 the --no-build-isolation was added, needed to access to petsc etc. packages during build of cython modules, but the -e flag was dropped. It appears that the latter breaks importing a python module with a cython submodule, from the source directory of that python module itself.

E.g. if you are in the animate/ source directory, "import animate" in python, it will try to import it from the local directory, but if that module was built without the -e flag, the
numbering.cpython-312-x86_64-linux-gnu.so is not available in animate/numbering/ but only in the installed directory (/usr/local/lib/...) and therefore the import will fail on "from .cython.numbering import to_petsc_local_numbering" Therefore you can no longer run pytest within the animate/ directory.

With the -e flag, the dynamic .so is placed in animate/numbering/ and it is able to "import animate" from within the local directory, as well as from anywhere else.