### PR TITLE
Mention `--no-build-isolation` in installation instructions

### DIFF
--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -51,7 +51,7 @@ git submodule update
 
 The package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
 ```
-python3 -m pip install -e <PACKAGE>
+python3 -m pip install --no-build-isolation -e <PACKAGE>
 ```
 
 ## Updating


### PR DESCRIPTION
This will be required following merge of https://github.com/mesh-adaptation/animate/issues/225.