### PR TITLE
Use `--no-build-isolation` in Docker files

### DIFF
--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -24,6 +24,6 @@ RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
     cd animate && git submodule init && git submodule update && cd .. && \
     cd movement && git submodule init && git submodule update && cd .. && \
     pip install -e adapt_common[dev] && \
-    pip install -e animate[dev] && \
+    pip install --no-build-isolation -e animate[dev] && \
     pip install -e movement[dev] && \
     pip install -e goalie[dev]

--- a/docker/Dockerfile.firedrake-parmmg_release
+++ b/docker/Dockerfile.firedrake-parmmg_release
@@ -24,6 +24,6 @@ RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
     cd animate && git submodule init && git submodule update && cd .. && \
     cd movement && git submodule init && git submodule update && cd .. && \
     pip install -e adapt_common[dev] && \
-    pip install -e animate[dev] && \
+    pip install --no-build-isolation -e animate[dev] && \
     pip install -e movement[dev] && \
     pip install -e goalie[dev]


### PR DESCRIPTION
The weekly Docker image build failed this weekend because `--no-build-isolation` now needs to be passed when `pip install`ing Animate.

See
https://github.com/mesh-adaptation/docs/actions/runs/22511376809/job/65222252163