### PR TITLE
Install build requirements for animate

### DIFF
--- a/.github/workflows/docker_firedrake-parmmg_main.yml
+++ b/.github/workflows/docker_firedrake-parmmg_main.yml
@@ -30,7 +30,7 @@ permissions: {}
 
 # Stop the workflow if a new run is requested
 concurrency:
-  group: $${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/docker_firedrake-parmmg_release.yml
+++ b/.github/workflows/docker_firedrake-parmmg_release.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - '.github/workflows/reusable_docker_build.yml'
       - '.github/workflows/docker_firedrake-parmmg_release.yml'
-      - 'docker/Dockerfile.firedrake-parmmg'
+      - 'docker/Dockerfile.firedrake-parmmg_release'
       - 'docker/Dockerfile.firedrake-um2n'
 
   # Build and push the Docker container when these files get changed on the main branch
@@ -16,7 +16,7 @@ on:
     paths:
       - '.github/workflows/reusable_docker_build.yml'
       - '.github/workflows/docker_firedrake-parmmg_release.yml'
-      - 'docker/Dockerfile.firedrake-parmmg'
+      - 'docker/Dockerfile.firedrake-parmmg_release'
       - 'docker/Dockerfile.firedrake-um2n'
 
   # Run test suite at 1AM on the first of the month

--- a/docker/Dockerfile.firedrake-parmmg
+++ b/docker/Dockerfile.firedrake-parmmg
@@ -24,6 +24,7 @@ RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
     cd animate && git submodule init && git submodule update && cd .. && \
     cd movement && git submodule init && git submodule update && cd .. && \
     pip install -e adapt_common[dev] && \
+    pip install -r animate/requirements-build.txt && \
     pip install --no-build-isolation -e animate[dev] && \
     pip install -e movement[dev] && \
     pip install -e goalie[dev]

--- a/docker/Dockerfile.firedrake-parmmg_release
+++ b/docker/Dockerfile.firedrake-parmmg_release
@@ -24,6 +24,7 @@ RUN git clone https://github.com/mesh-adaptation/adapt_common.git && \
     cd animate && git submodule init && git submodule update && cd .. && \
     cd movement && git submodule init && git submodule update && cd .. && \
     pip install -e adapt_common[dev] && \
+    pip install -r animate/requirements-build.txt && \
     pip install --no-build-isolation -e animate[dev] && \
     pip install -e movement[dev] && \
     pip install -e goalie[dev]


### PR DESCRIPTION
Adds `pip install -r animate/requirements-build.txt` step before building/installing animate. This is needed in the release container because there firedrake is installed directly from a pypi wheel and thus build requirements like Cython and a recent enough setuptools are not available. In the main container firedrake has been built locally and thus these are available already. Adding steps in both cases though for consistency.

Addresses https://github.com/mesh-adaptation/animate/pull/241