### PR TITLE
Update wiki installation instructions for animate build requirements

### DIFF
--- a/.github/workflows/reusable_test_suite.yml
+++ b/.github/workflows/reusable_test_suite.yml
@@ -45,6 +45,7 @@ jobs:
           git submodule init
           git submodule update
           pip uninstall ${REPO_NAME} -y || true
+          if test -f ${REPO_NAME}/requirements-build.txt; then pip install -r ${REPO_NAME}/requirements-build.txt; fi
           pip install --no-build-isolation -e .[dev]
 
       - run: make lint

--- a/wiki/Installation-Instructions.md
+++ b/wiki/Installation-Instructions.md
@@ -49,6 +49,11 @@ git submodule init
 git submodule update
 ```
 
+For Animate only, we require one additional step before installation:
+```
+python3 -m pip install -r animate/build-requirements.txt
+```
+
 The package can be [installed using pip](https://pip.pypa.io/en/stable/topics/local-project-installs/):
 ```
 python3 -m pip install --no-build-isolation -e <PACKAGE>


### PR DESCRIPTION
Also add pip install -r requirements-build.txt step to reusable test suite. At the moment, this is not strictly needed because the requirements should have been installed during the build of the container, but if in a PR we change the build requirements, we do want to test this step.
